### PR TITLE
Correct requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ tqdm
 pandas
 tensorboard>=1.14
 pyyaml 
-sklearn 
+scikit-learn 
 h5py 
  


### PR DESCRIPTION
Corrected the problem that in requirement.txt, scikit-learn was abbreviated as sklearn, causing pip to fail.